### PR TITLE
Update based newest python package. queue->multiprocessing

### DIFF
--- a/upcheck.py
+++ b/upcheck.py
@@ -5,7 +5,7 @@
 import sys
 import requests
 import threading
-from queue import Queue
+from multiprocessing import Queue
 
 urls = ["https://%s"%line.strip('\n') for line in open(sys.argv[1],'r')]
 


### PR DESCRIPTION
using the upcheck.py for subdirectory testing if live. Always encountered error on line 8. Unable to detect queue module. 
queue module was already replaced into multiprocessing package. 